### PR TITLE
Modify overlay style to hide playlists effectively, fix overlapping issue by reducing padding.

### DIFF
--- a/content.js
+++ b/content.js
@@ -62,15 +62,15 @@ const distractingKeywordMessages = {
 
 const motivationalOverlayStyle = `
   position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
+  top: -10px; left: 0;
+  width: 100%; height: 105%;
   background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 10px;
+  padding: 5px;
   font-size: 14px;
   font-weight: bold;
   color: #222;


### PR DESCRIPTION
Fixed the playlist issue - #9   by increasing the height and moving the overlay upwards using a negative margin.

**Initial approach planned :**  To increase the height only if this selector **yt-collection-thumbnail-view-model**
 (exclusive for playlists) is located. 
 
 **Issue with the above approach:** It will cause inconsistencies in the overlay sizes in a page if there are combinations of standalone videos and playlists.
 
Used a simpler approach to edit the CSS declared initially to maintain a clean UI. Also fixed overlapping issue present in the overlays earlier.

Before editing the padding:
<img width="951" height="653" alt="Screenshot 2025-12-06 at 11 03 00 PM" src="https://github.com/user-attachments/assets/97a852ce-ea47-4585-9f98-1a70746a009c" />

After editing the padding:
<img width="951" height="481" alt="Screenshot 2025-12-06 at 11 01 43 PM" src="https://github.com/user-attachments/assets/3db21f9d-1d08-43e9-be98-9048d7b46502" />

UI after fixing the playlist issue:

<img width="429" height="764" alt="Screenshot 2025-12-06 at 11 08 33 PM" src="https://github.com/user-attachments/assets/df523d70-99ee-40a5-a036-cdcf5a9f47ae" />