### PR TITLE
Feat/analytics clear or append based on toggle

### DIFF
--- a/content.js
+++ b/content.js
@@ -79,6 +79,7 @@ const motivationalOverlayStyle = `
 `;
 
 let filterRunning = false;
+let isFilterEnabled = false;
 
 let stats = {
   filteredCount: 0,
@@ -335,7 +336,7 @@ const processVideo = async (item) => {
 };
 
 function applyFilter() {
-  if (filterRunning) return;
+  if (filterRunning || !isFilterEnabled) return;
   filterRunning = true;
 
   // Use requestAnimationFrame for smooth animations
@@ -374,76 +375,104 @@ function applyFilter() {
 // Modify observer to use Intersection Observer for scroll detection
 function initFilter() {
   try {
-    // Reset stats when filter is initialized
-    stats = {
-      filteredCount: 0,
-      educationalCount: 0,
-      totalVideos: 0,
-      watchTime: {
-        educational: 0,
-        entertainment: 0
-      }
-    };
-
-    filterRunning = false;
-    applyFilter();
-    trackVideoWatchTime();
-
-    // Create mutation observer for new content
-    const mutationObserver = new MutationObserver(() => {
-      if (!filterRunning) {
-        applyFilter();
+    // Check persist stats setting
+    chrome.storage.sync.get(['persistStats'], (result) => {
+      if (result.persistStats) {
+        // If persisting stats, load existing stats instead of resetting
+        chrome.storage.local.get(['videoStats'], (statsResult) => {
+          if (statsResult.videoStats) {
+            stats = { ...statsResult.videoStats };
+          } else {
+            // Fallback to reset if no stats exist
+            stats = {
+              filteredCount: 0,
+              educationalCount: 0,
+              totalVideos: 0,
+              watchTime: {
+                educational: 0,
+                entertainment: 0
+              }
+            };
+          }
+          initializeFilter();
+        });
+      } else {
+        // Reset stats when filter is initialized (if not persisting)
+        stats = {
+          filteredCount: 0,
+          educationalCount: 0,
+          totalVideos: 0,
+          watchTime: {
+            educational: 0,
+            entertainment: 0
+          }
+        };
+        initializeFilter();
       }
     });
 
-    // Create intersection observer for scroll detection
-    const intersectionObserver = new IntersectionObserver((entries) => {
-      const processEntries = async () => {
-        for (const entry of entries) {
-          if (entry.isIntersecting && !entry.target.hasAttribute('data-processed')) {
-            await processVideo(entry.target);
+    function initializeFilter() {
+      filterRunning = false;
+      applyFilter();
+      trackVideoWatchTime();
+
+      // Create mutation observer for new content
+      const mutationObserver = new MutationObserver(() => {
+        if (!filterRunning && isFilterEnabled) {
+          applyFilter();
+        }
+      });
+
+      // Create intersection observer for scroll detection
+      const intersectionObserver = new IntersectionObserver((entries) => {
+        const processEntries = async () => {
+          for (const entry of entries) {
+            if (entry.isIntersecting && !entry.target.hasAttribute('data-processed')) {
+              await processVideo(entry.target);
+            }
           }
+        };
+        processEntries().catch(error => console.log('Error processing entries:', error));
+      }, {
+        root: null,
+        rootMargin: '100px', // Increased margin for better pre-loading
+        threshold: 0.1
+      });
+
+      // Observe DOM changes
+      mutationObserver.observe(document.body, { 
+        childList: true, 
+        subtree: true 
+      });
+
+      // Function to observe new videos
+      const observeNewVideos = () => {
+        const unprocessedVideos = document.querySelectorAll(`
+          ytd-rich-item-renderer:not([data-processed]), 
+          ytd-video-renderer:not([data-processed]),
+          ytd-grid-video-renderer:not([data-processed])
+        `);
+        unprocessedVideos.forEach(video => {
+          intersectionObserver.observe(video);
+        });
+      };
+
+      // Observe initial videos
+      observeNewVideos();
+
+      // Add observer for new videos being added
+      const newVideoObserver = new MutationObserver(observeNewVideos);
+      newVideoObserver.observe(document.body, { childList: true, subtree: true });
+
+      return {
+        disconnect: () => {
+          mutationObserver.disconnect();
+          intersectionObserver.disconnect();
+          newVideoObserver.disconnect();
         }
       };
-      processEntries().catch(error => console.log('Error processing entries:', error));
-    }, {
-      root: null,
-      rootMargin: '100px', // Increased margin for better pre-loading
-      threshold: 0.1
-    });
-
-    // Observe DOM changes
-    mutationObserver.observe(document.body, { 
-      childList: true, 
-      subtree: true 
-    });
-
-    // Function to observe new videos
-    const observeNewVideos = () => {
-      const unprocessedVideos = document.querySelectorAll(`
-        ytd-rich-item-renderer:not([data-processed]), 
-        ytd-video-renderer:not([data-processed]),
-        ytd-grid-video-renderer:not([data-processed])
-      `);
-      unprocessedVideos.forEach(video => {
-        intersectionObserver.observe(video);
-      });
-    };
-
-    // Observe initial videos
-    observeNewVideos();
-
-    // Add observer for new videos being added
-    const newVideoObserver = new MutationObserver(observeNewVideos);
-    newVideoObserver.observe(document.body, { childList: true, subtree: true });
-
-    return {
-      disconnect: () => {
-        mutationObserver.disconnect();
-        intersectionObserver.disconnect();
-        newVideoObserver.disconnect();
-      }
-    };
+    }
+    return null;
   } catch (error) {
     console.log('Init filter error:', error);
     return null;
@@ -452,70 +481,101 @@ function initFilter() {
 
 let observer = null;
 chrome.storage.sync.get(["distractionFilterEnabled"], result => {
+  isFilterEnabled = !!result.distractionFilterEnabled;
   if (result.distractionFilterEnabled) {
-    if (observer) {
-      observer.disconnect();
+    if (window.currentObservers) {
+      window.currentObservers.mutation.disconnect();
+      window.currentObservers.intersection.disconnect();
+      window.currentObservers.newVideo.disconnect();
     }
-    observer = initFilter();
+    initFilter();
   }
 });
 
-// Modify chrome.storage.onChanged listener to clear stats when filter is disabled
+// Modify chrome.storage.onChanged listener to conditionally clear stats when filter is disabled
 chrome.storage.onChanged.addListener((changes, namespace) => {
   if (namespace === 'sync' && changes.distractionFilterEnabled) {
     if (changes.distractionFilterEnabled.newValue) {
-      if (observer) {
-        observer.disconnect();
+      isFilterEnabled = true;
+      if (window.currentObservers) {
+        window.currentObservers.mutation.disconnect();
+        window.currentObservers.intersection.disconnect();
+        window.currentObservers.newVideo.disconnect();
       }
-      observer = initFilter();
+      initFilter();
     } else {
-      if (observer) {
-        observer.disconnect();
-        observer = null;
+      isFilterEnabled = false;
+      if (window.currentObservers) {
+        window.currentObservers.mutation.disconnect();
+        window.currentObservers.intersection.disconnect();
+        window.currentObservers.newVideo.disconnect();
+        window.currentObservers = null;
       }
 
-      // Clear all stats from storage
-      chrome.storage.local.set({
-        videoStats: {
-          filteredCount: 0,
-          educationalCount: 0,
-          totalVideos: 0,
-          watchTime: {
-            educational: 0,
-            entertainment: 0
-          },
-          educationalPercentage: 0,
-          productivityScore: 0,
-          lastUpdated: Date.now()
+      // Check persist stats setting before clearing
+      chrome.storage.sync.get(['persistStats'], (result) => {
+        if (!result.persistStats) {
+          // Only clear stats if persist is disabled
+          chrome.storage.local.set({
+            videoStats: {
+              filteredCount: 0,
+              educationalCount: 0,
+              totalVideos: 0,
+              watchTime: {
+                educational: 0,
+                entertainment: 0
+              },
+              educationalPercentage: 0,
+              productivityScore: 0,
+              lastUpdated: Date.now()
+            }
+          });
+
+          // Reset stats object
+          stats = {
+            filteredCount: 0,
+            educationalCount: 0,
+            totalVideos: 0,
+            watchTime: {
+              educational: 0,
+              entertainment: 0
+            }
+          };
+
+          // Remove overlays and reset styles
+          document.querySelectorAll('.focus-filter-overlay').forEach(overlay => {
+            overlay.remove();
+          });
+
+          document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer, ytd-grid-video-renderer').forEach(item => {
+            item.style.opacity = '';
+            item.style.pointerEvents = '';
+            item.removeAttribute('data-processed');
+
+            const thumbnails = item.querySelectorAll('ytd-channel-renderer img, img#img, yt-image img, ytd-thumbnail img, #thumbnail img');
+            thumbnails.forEach(thumbnail => {
+              thumbnail.style.display = '';
+              thumbnail.style.opacity = '';
+            });
+          });
+        } else {
+          // If persisting stats, just remove overlays and reset styles without clearing stats
+          document.querySelectorAll('.focus-filter-overlay').forEach(overlay => {
+            overlay.remove();
+          });
+
+          document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer, ytd-grid-video-renderer').forEach(item => {
+            item.style.opacity = '';
+            item.style.pointerEvents = '';
+            item.removeAttribute('data-processed');
+
+            const thumbnails = item.querySelectorAll('ytd-channel-renderer img, img#img, yt-image img, ytd-thumbnail img, #thumbnail img');
+            thumbnails.forEach(thumbnail => {
+              thumbnail.style.display = '';
+              thumbnail.style.opacity = '';
+            });
+          });
         }
-      });
-
-      // Reset stats object
-      stats = {
-        filteredCount: 0,
-        educationalCount: 0,
-        totalVideos: 0,
-        watchTime: {
-          educational: 0,
-          entertainment: 0
-        }
-      };
-
-      // Remove overlays and reset styles
-      document.querySelectorAll('.focus-filter-overlay').forEach(overlay => {
-        overlay.remove();
-      });
-
-      document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer, ytd-grid-video-renderer').forEach(item => {
-        item.style.opacity = '';
-        item.style.pointerEvents = '';
-        item.removeAttribute('data-processed');
-
-        const thumbnails = item.querySelectorAll('ytd-channel-renderer img, img#img, yt-image img, ytd-thumbnail img, #thumbnail img');
-        thumbnails.forEach(thumbnail => {
-          thumbnail.style.display = '';
-          thumbnail.style.opacity = '';
-        });
       });
     }
   }
@@ -531,9 +591,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       window.location.reload();
       return true;
     } else {
-      if (observer) {
-        observer.disconnect();
-        observer = null;
+      isFilterEnabled = false;
+      if (window.currentObservers) {
+        window.currentObservers.mutation.disconnect();
+        window.currentObservers.intersection.disconnect();
+        window.currentObservers.newVideo.disconnect();
+        window.currentObservers = null;
       }
       
       // Immediately remove all filter-related styles

--- a/popup.html
+++ b/popup.html
@@ -57,6 +57,86 @@
         margin-bottom: 0.5rem;
       }
 
+      .settings-container {
+        margin: 0 1rem 1rem;
+        padding: 0.75rem;
+        background: #f0fdf4;
+        border-radius: var(--radius);
+        border: 1px solid #dcfce7;
+      }
+
+      .settings-title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #15803d;
+        margin-bottom: 0.5rem;
+      }
+
+      .setting-item {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.5rem;
+      }
+
+      .setting-item:last-child {
+        margin-bottom: 0;
+      }
+
+      .setting-label {
+        font-size: 0.75rem;
+        color: #16a34a;
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+
+      .setting-switch {
+        position: relative;
+        display: inline-block;
+        width: 36px;
+        height: 18px;
+      }
+
+      .setting-switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+
+      .setting-slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: linear-gradient(135deg, #cbd5e1, #94a3b8);
+        transition: all 0.3s ease;
+        border-radius: 18px;
+        border: 1px solid #b4e50d;
+      }
+
+      .setting-slider:before {
+        position: absolute;
+        content: "";
+        height: 14px;
+        width: 14px;
+        left: 2px;
+        bottom: 2px;
+        background: linear-gradient(135deg, #ffffff, #f8fafc);
+        transition: all 0.3s ease;
+        border-radius: 50%;
+      }
+
+      .setting-switch input:checked + .setting-slider {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+      }
+
+      .setting-switch input:checked + .setting-slider:before {
+        transform: translateX(18px);
+      }
+
       .subtitle {
         font-size: 0.875rem;
         color: rgba(255, 255, 255, 0.9);
@@ -411,6 +491,22 @@
       </div>
       <div class="score-label">Productivity Score</div>
       <div class="score-breakdown">Watch time (60%) | Video ratio (40%)</div>
+    </div>
+
+    <div class="settings-container">
+      <div class="settings-title">Settings</div>
+      <div class="setting-item">
+        <span class="setting-label">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+          </svg>
+          Persist Stats
+        </span>
+        <label class="setting-switch">
+          <input type="checkbox" id="persistStats" />
+          <span class="setting-slider"></span>
+        </label>
+      </div>
     </div>
 
     <div class="credit">Hide distractions. Grow your focus.</div>

--- a/popup.html
+++ b/popup.html
@@ -59,16 +59,14 @@
 
       .settings-container {
         margin: 0 1rem 1rem;
-        padding: 0.75rem;
-        background: #f0fdf4;
-        border-radius: var(--radius);
-        border: 1px solid #dcfce7;
+        padding: 0.75rem 0.25rem 0.5rem 0.25rem;
+        background: #fff;
       }
 
       .settings-title {
         font-size: 0.875rem;
         font-weight: 600;
-        color: #15803d;
+        color: #333;
         margin-bottom: 0.5rem;
       }
 
@@ -85,7 +83,7 @@
 
       .setting-label {
         font-size: 0.75rem;
-        color: #16a34a;
+        color: #94a3b8;
         display: flex;
         align-items: center;
         gap: 0.25rem;
@@ -395,7 +393,18 @@
       </div>
       <div class="subtitle">YouTube Focus Buddy</div>
     </div>
-
+    <div class="settings-container">
+      <div class="settings-title">Persist Analytics</div>
+      <div class="setting-item">
+        <span class="setting-label">
+          Keep tracking data when filter is disabled
+        </span>
+        <label class="setting-switch">
+          <input type="checkbox" id="persistStats" />
+          <span class="setting-slider"></span>
+        </label>
+      </div>
+    </div>
     <div class="stats-container">
       <div class="stat-item">
         <span class="stat-label">
@@ -493,21 +502,7 @@
       <div class="score-breakdown">Watch time (60%) | Video ratio (40%)</div>
     </div>
 
-    <div class="settings-container">
-      <div class="settings-title">Settings</div>
-      <div class="setting-item">
-        <span class="setting-label">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-          </svg>
-          Persist Stats
-        </span>
-        <label class="setting-switch">
-          <input type="checkbox" id="persistStats" />
-          <span class="setting-slider"></span>
-        </label>
-      </div>
-    </div>
+
 
     <div class="credit">Hide distractions. Grow your focus.</div>
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', function () {
   loaderMessage.textContent = messages[Math.floor(Math.random() * messages.length)];
 
   const toggle = document.getElementById('toggleFilter');
+  const persistStatsToggle = document.getElementById('persistStats');
   const filteredCount = document.getElementById('filteredCount');
   const educationalCount = document.getElementById('educationalCount');
   const productivityScore = document.getElementById('productivityScore');
@@ -45,12 +46,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Load the current setting and stats
   Promise.all([
-    new Promise(resolve => chrome.storage.sync.get(['distractionFilterEnabled'], resolve)),
+    new Promise(resolve => chrome.storage.sync.get(['distractionFilterEnabled', 'persistStats'], resolve)),
     new Promise(resolve => chrome.storage.local.get(['videoStats'], resolve)),
     minimumLoaderTime
   ]).then(([settingsResult, statsResult]) => {
-    // Update toggle state
+    // Update toggle states
     toggle.checked = !!settingsResult.distractionFilterEnabled;
+    persistStatsToggle.checked = !!settingsResult.persistStats;
     
     // Update stats display
     if (statsResult.videoStats) {
@@ -82,6 +84,10 @@ document.addEventListener('DOMContentLoaded', function () {
     // Hide loader even if there's an error
     loaderContainer.style.display = 'none';
   });
+  // Listen for changes to the persist stats toggle
+  persistStatsToggle.addEventListener("change", () => {
+    chrome.storage.sync.set({ persistStats: persistStatsToggle.checked });
+  });
   // Listen for changes to the toggle switch
   toggle.addEventListener("change", () => {
     // Show loader when toggle changes
@@ -109,54 +115,88 @@ document.addEventListener('DOMContentLoaded', function () {
           }, 500);
         });
       } else {
-        // If disabling, clear stats and notify tabs
-        chrome.storage.local.set({
-          lastStats: {
-            filteredCount: 0,
-            educationalCount: 0,
-            totalVideos: 0,
-            educationalTime: '0 min',
-            educationalPercentage: 0,
-            productivityScore: 0,
-            timestamp: Date.now()
-          }
-        }, () => {
-          chrome.tabs.query({ url: "*://*.youtube.com/*" }, (tabs) => {
-            if (tabs.length > 0) {
-              const messagePromises = tabs.map(tab => {
-                return new Promise((resolve) => {
-                  chrome.tabs.sendMessage(
-                    tab.id, 
-                    { type: 'toggleFilter', enabled: false },
-                    (response) => {
-                      if (chrome.runtime.lastError) {
-                        console.log('Tab communication error:', chrome.runtime.lastError);
-                      }
-                      resolve();
-                    }
-                  );
-                });
-              });
+        // If disabling, check persist stats setting
+        chrome.storage.sync.get(['persistStats'], (result) => {
+          if (!result.persistStats) {
+            // Only reset stats if persist is disabled
+            chrome.storage.local.set({
+              lastStats: {
+                filteredCount: 0,
+                educationalCount: 0,
+                totalVideos: 0,
+                educationalTime: '0 min',
+                educationalPercentage: 0,
+                productivityScore: 0,
+                timestamp: Date.now()
+              }
+            }, () => {
+              chrome.tabs.query({ url: "*://*.youtube.com/*" }, (tabs) => {
+                if (tabs.length > 0) {
+                  const messagePromises = tabs.map(tab => {
+                    return new Promise((resolve) => {
+                      chrome.tabs.sendMessage(
+                        tab.id, 
+                        { type: 'toggleFilter', enabled: false },
+                        (response) => {
+                          if (chrome.runtime.lastError) {
+                            console.log('Tab communication error:', chrome.runtime.lastError);
+                          }
+                          resolve();
+                        }
+                      );
+                    });
+                  });
 
-              Promise.all(messagePromises).then(() => {
-                // Reset all stats displays to zero
-                filteredCount.textContent = '0';
-                educationalCount.textContent = '0';
-                totalVideos.textContent = '0';
-                educationalTime.textContent = '0 min';
-                educationalProgress.style.width = '0%';
-                educationalPercentage.textContent = '0%';
-                productivityScore.textContent = '0%';
-                
-                // Hide loader after processing
-                setTimeout(() => {
+                  Promise.all(messagePromises).then(() => {
+                    // Reset all stats displays to zero
+                    filteredCount.textContent = '0';
+                    educationalCount.textContent = '0';
+                    totalVideos.textContent = '0';
+                    educationalTime.textContent = '0 min';
+                    educationalProgress.style.width = '0%';
+                    educationalPercentage.textContent = '0%';
+                    productivityScore.textContent = '0%';
+
+                    // Hide loader after processing
+                    setTimeout(() => {
+                      loaderContainer.style.display = 'none';
+                    }, 500);
+                  });
+                } else {
                   loaderContainer.style.display = 'none';
-                }, 500);
+                }
               });
-            } else {
-              loaderContainer.style.display = 'none';
-            }
-          });
+            });
+          } else {
+            // If persisting stats, just notify tabs without resetting
+            chrome.tabs.query({ url: "*://*.youtube.com/*" }, (tabs) => {
+              if (tabs.length > 0) {
+                const messagePromises = tabs.map(tab => {
+                  return new Promise((resolve) => {
+                    chrome.tabs.sendMessage(
+                      tab.id, 
+                      { type: 'toggleFilter', enabled: false },
+                      (response) => {
+                        if (chrome.runtime.lastError) {
+                          console.log('Tab communication error:', chrome.runtime.lastError);
+                        }
+                        resolve();
+                      }
+                    );
+                  });
+                });
+
+                Promise.all(messagePromises).then(() => {
+                  // Hide loader
+                  setTimeout(() => {
+                    loaderContainer.style.display = 'none';
+                  }, 500);
+                });
+              } else {
+                loaderContainer.style.display = 'none';
+              }
+            });
+          }
         });
       }
     });


### PR DESCRIPTION
🚀 Feature: Analytics Persistence Toggle & UI Improvements
What

Introduces a user-controlled toggle to manage how analytics data is handled, along with updates to the settings UI.

Changes
Added toggle to control analytics persistence
Clears analytics data when toggle is OFF
Appends/retains analytics data when toggle is ON
Updated settings UI to reflect analytics preferences
Improved styling and user experience for settings panel
Why

This gives users control over their analytics data, ensuring it aligns with their preferences while improving clarity in the UI.

How to Test
Go to Settings
Toggle analytics ON → verify data is retained/appended
Toggle analytics OFF → verify data is cleared
Refresh and ensure behavior persists correctly